### PR TITLE
Test out the `public_restricted` policy

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -1,30 +1,28 @@
 version: 1
 reporting: checks-v1
 policy:
-  pullRequests: collaborators
+  pullRequests: public_restricted
 tasks:
-  - $if: 'tasks_for == "github-push"'
+  - $if: 'tasks_for == "github-pull-request-untrusted"'
     then:
+      taskQueueId: built-in/fail
+      schedulerId: taskcluster-ui
+      created: {$fromNow: ''}
+      deadline: {$fromNow: '1 day'}
+      payload: {}
+      metadata:
+        name: example-task-1
+        description: An **example** task
+        owner: ykurmyza@mozilla.com
+        source: http://taskcluster/tasks/create
+    else:
       taskQueueId: built-in/succeed
       schedulerId: taskcluster-ui
       created: {$fromNow: ''}
       deadline: {$fromNow: '1 day'}
       payload: {}
       metadata:
-        name: example-task-push-1
+        name: example-task-1
         description: An **example** task
         owner: ykurmyza@mozilla.com
         source: http://taskcluster/tasks/create
-    else:
-      $if: 'tasks_for == "github-pull-request"'
-      then:
-        taskQueueId: built-in/succeed
-        schedulerId: taskcluster-ui
-        created: {$fromNow: ''}
-        deadline: {$fromNow: '1 day'}
-        payload: {}
-        metadata:
-          name: example-task-pull-1
-          description: An **example** task
-          owner: ykurmyza@mozilla.com
-          source: http://taskcluster/tasks/create


### PR DESCRIPTION
Switches policy to `public_restricted` and sets the task to fail if opened by a non-collaborator.